### PR TITLE
Thrown exception issue fixed by setting list type.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,7 @@ class _State extends State<MyApp> {
 
   Animals _selected = Animals.Cat;
   String _value = 'Make a Selection';
-  List _items = new List();
+  List<PopupMenuEntry<Animals>> _items = new List<PopupMenuEntry<Animals>>();
 
 
   @override


### PR DESCRIPTION
May 10th 2018:
Exception was thrown by the debug console while testing the popup menu from Lecture 4 (Udemy Intermediate): "Another exception was thrown: type 'List<dynamic>' is not a subtype of type 'List<PopupMenuEntry<Animals>>'".

Solved by setting the list type to the suggestion from the debug console.

Specs:
Flutter 0.3.2 • channel beta • https://github.com/flutter/flutter.git
Framework • revision 44b7e7d3f4 (3 weeks ago) • 2018-04-20 01:02:44 -0700
Engine • revision 09d05a3891
Tools • Dart 2.0.0-dev.48.0.flutter-fe606f890b